### PR TITLE
Surveyor’s can now be extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,15 @@ job than parsing `.srv` files!
                                             format
           
           "surveyors": {                    Optional - members of the survey team
-            "Dan Crowl":   "sketch", 
-            "Keith Ortiz": "frontsights", 
-            "Chip Hopper": "backsights", 
-            "Peter Quick": [
-              "lead tape",                  You can specify multiple roles in an array
-              "photos"                        
-            ],
+            "Dan Crowl": {roles:"sketch"},
+            "Peter Quick":
+              {
+                roles:                      You can specify multiple roles in an array or scalar
+                  [
+                    "lead tape",
+                    "photos"
+                  ],
+              }
             "Larry Bean": null              Use null if you don't want to specify a role
           }
 


### PR DESCRIPTION
This change allows programs to add extra metadata
(other than just the roles) for a surveyor. 
Roles are now in there own “roles” property.
