### PR TITLE
Remove mils

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Always use UTF-8.
 "min" : minutes  (1/60   degree)
 "sec" : seconds  (1/60   minute)
 "grad": gradians (1/400  circle)
-"mil" : mils     (1/6400 circle)
 ```
 
 ### Additional Inclination Unit

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Always use UTF-8.
                                             Supported units:
                                             "deg" : degrees
                                             "grad": gradians
-                                            "mil" : mils (1/6400 of a circle)
 
           "azmBacksightsCorrected": false,  Required - true if azimuth backsights are corrected,
                                             false if not
@@ -178,7 +177,7 @@ Always use UTF-8.
                                             Additional supported unit:
                                             "%": percent grade
           
-          "incBsUnit": "mil",               Optional - overrides default unit for
+          "incBsUnit": "deg",               Optional - overrides default unit for
                                             backsight inclinations
           
           "distCorrection": "1.5",          Optional distance - correction added to the


### PR DESCRIPTION
@vpicaver 
I changed my mind, angular mils are a terrible idea.  There are three different definitions:
* 1/6000 (Warsaw Pact)
* 1/6300 (Swedish)
* 1/6400 (NATO)

To make matters worse, the Survex documentation for `*units` claims that mils and gradians (1/400) are the same thing, which is a **huge wtf**.

> (360 degrees = 400 grads (also known as Mils))

So using mils is rotten from a data archeology perspective (in a distant future in which someone is trying to resurrect cave data, and the documentation for the file format is gone).